### PR TITLE
Report CLI error in main function

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -129,7 +129,7 @@ fn format_annotations(annotations: Vec<PyAnnotation>, format: &str) -> PyResult<
 // @todo: remove once https://github.com/PyO3/maturin/issues/368 is resolved
 #[pyfunction]
 fn run_cli(args: Vec<String>) -> PyResult<()> {
-    let _ = run(args);
+    run(args).map_err(|err| PyValueError::new_err(err.to_string()))?;
     Ok(())
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -67,12 +67,12 @@ fn extract_annotations(content: &str, file_type: &str) -> PyResult<Vec<PyAnnotat
         "py" => FileType::Python,
         "rs" => FileType::Rust,
         "js" => FileType::JavaScript,
-        _ => return Err(PyErr::new::<PyValueError, _>("Invalid file type")),
+        _ => return Err(PyValueError::new_err("Invalid file type")),
     };
 
     let dummy_path = std::path::PathBuf::from("<string>");
     let annotations = parser::extract_annotations(content, &ft, &dummy_path)
-        .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
 
     Ok(annotations
         .into_iter()
@@ -118,16 +118,12 @@ fn format_annotations(annotations: Vec<PyAnnotation>, format: &str) -> PyResult<
     let adapter = match format {
         "json" => RenderAdapter::Json(JsonAdapter),
         "yaml" => RenderAdapter::Yaml(YamlAdapter),
-        _ => {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                "Invalid format",
-            ))
-        }
+        _ => return Err(PyValueError::new_err("Invalid format")),
     };
 
     adapter
         .format(&annotations)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // @todo: remove once https://github.com/PyO3/maturin/issues/368 is resolved


### PR DESCRIPTION
`run_cli` was just swallowing the error, so nothing was displayed to the user if an error happened.

I'm not sure if just throwing `ValueError` here is the best idea, but it beats doing nothing.