### PR TITLE
Construct Tree Sitter queries only once

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ streaming-iterator = "0.1.9"
 
 [features]
 extension-module = ["pyo3/extension-module"]
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,7 @@
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    anot::cli::run(args)?;
+    Ok(())
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,7 +30,6 @@ pub fn extract_annotations(
     let mut parser = tree_sitter::Parser::new();
     let language = file_type.tree_sitter_language();
     parser.set_language(&language)?;
-    let query = file_type.tree_sitter_query();
 
     // Parse the full source code
     let source = source_code.as_bytes();
@@ -38,9 +37,9 @@ pub fn extract_annotations(
         .parse(source, None)
         .ok_or_else(|| anyhow::anyhow!("Failed to parse source code"))?;
 
-    let query = tree_sitter::Query::new(&language, query)?;
+    let query = file_type.tree_sitter_query();
     let mut query_cursor = tree_sitter::QueryCursor::new();
-    let mut matches = query_cursor.matches(&query, tree.root_node(), source);
+    let mut matches = query_cursor.matches(query, tree.root_node(), source);
 
     let mut annotations = Vec::new();
 


### PR DESCRIPTION
This is the speed-up mentioned in https://github.com/flywhl/anot/pull/14#discussion_r1916833427. I figured it was easy enough to just do it. I can post more rigorous results, but here's why I did this:

I was benchmarking the tool to see if filtering afterwards made any difference. I noticed that when parsing multiple files, the same query was being re-created, and it wasn't free. My test case was taking https://github.com/rust-lang/rust, adding tags to the comments with sed [1], and running `anot .` in the repository root. Before this PR, it took ~50s. Now, it takes ~12s. It doesn't make any difference if it runs on a single file.

[1] `git ls-files '*.rs' | xargs sed -i '/[^\/]\/\/ /s/\/\/ /\/\/ @tag: /'`