### PR TITLE
Respect .gitignore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ serde_yaml = "0.9"
 clap = { version = "4.5", features = ["derive"] }
 thiserror = "1.0"
 pyo3 = "0.23.4"
-walkdir = "2.5.0"
 tree-sitter = "0.24.7"
 tree-sitter-rust = "0.23.2"
 tree-sitter-javascript = "0.23.1"
 tree-sitter-python = "0.23.6"
 streaming-iterator = "0.1.9"
+ignore = "0.4.23"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::LazyLock;
-use walkdir::WalkDir;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FileType {
@@ -71,21 +70,29 @@ pub fn determine_file_type(path: &PathBuf) -> Result<FileType> {
     FileType::try_from(path)
 }
 
+/// Find all files from support file types. See [FileType].
+///
+/// Ignores files in `.gitignore` and `.ignore`, follows symlinks and ignores hidden files.
+///
+/// # Arguments
+///
+/// * `path` - Path to directory to search recursively.
+///
+/// # Returns
+/// Paths of files from supported file types.
+///
+/// # Errors
+/// If there are errors navigating the file system.
 pub fn scan_directory(path: &PathBuf) -> Result<Vec<PathBuf>> {
-    let mut files = Vec::new();
-    for entry in WalkDir::new(path)
+    Ok(ignore::WalkBuilder::new(path)
         .follow_links(true)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        if entry.file_type().is_file() {
-            let path = entry.path().to_path_buf();
-            if determine_file_type(&path).is_ok() {
-                files.push(path);
-            }
-        }
-    }
-    Ok(files)
+        .hidden(false)
+        .build()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
+        .map(|e| e.into_path())
+        .filter(|p| determine_file_type(p).is_ok())
+        .collect())
 }
 
 #[cfg(test)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -45,6 +45,7 @@ static TS_QUERY_JAVASCRIPT: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
 });
 
 impl FileType {
+    /// Get [Tree Sitter query](tree_sitter::Query) for file type.
     pub fn tree_sitter_query(&self) -> &'static tree_sitter::Query {
         match self {
             FileType::Python => &TS_QUERY_PYTHON,
@@ -53,6 +54,7 @@ impl FileType {
         }
     }
 
+    /// Get [Tree Sitter language](tree_sitter::Language) object from file type.
     pub fn tree_sitter_language(&self) -> tree_sitter::Language {
         match self {
             FileType::Python => tree_sitter_python::LANGUAGE.into(),
@@ -62,10 +64,18 @@ impl FileType {
     }
 }
 
+/// Read content of file in `path` to a String.
+///
+/// # Errors
+/// If there's a problem reading the file (e.g. if it doesn't exist).
 pub fn read_file(path: &PathBuf) -> Result<String> {
     fs::read_to_string(path).map_err(|e| anyhow::anyhow!("Failed to read file: {}", e))
 }
 
+/// Determine file type from `path` extension. See [FileType].
+///
+/// # Errors
+/// If the file type is not supported.
 pub fn determine_file_type(path: &PathBuf) -> Result<FileType> {
     FileType::try_from(path)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,7 +20,6 @@ pub const TAG: &str = "@";
 ///
 /// # Errors
 /// If parsing the source code fails, or the tree-sitter query is invalid.
-/// ```
 pub fn extract_annotations(
     source_code: &str,
     file_type: &FileType,

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.9"
 
 [[package]]
 name = "anot"
-version = "0.0.4"
+version = "0.0.3"
 source = { virtual = "." }
 dependencies = [
     { name = "maturin" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,6 @@ requires-python = ">=3.9"
 
 [[package]]
 name = "anot"
-version = "0.0.3"
 source = { virtual = "." }
 dependencies = [
     { name = "maturin" },


### PR DESCRIPTION
Instead of using `walkdir` to gather the files to sure, we use `ripgrep`'s `.gitignore` crate.

Closes #20.